### PR TITLE
Add responsive blog

### DIFF
--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -1,0 +1,8 @@
+<a href="/demo" class="nav-link">Demo</a>
+<a href="https://github.com/hospitalrun" class="nav-link">Source</a>
+<a href="/beta" class="nav-link">Beta</a>
+<a href="/events" class="nav-link" target="_blank">Hack Events</a>
+<a href="/team" class="nav-link" target="_blank">Team</a>
+<a href="/blog" class="nav-link">Blog</a>
+<a href="/contribute" class="nav-link" target="_blank">Contribute</a>
+<a href="http://goo.gl/NCJDnJ" class="nav-link" target="_blank">Why HospitalRun?</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,12 +1,5 @@
 <nav class="site-nav">
-  <a href="/demo" class="nav-link">Demo</a>
-  <a href="https://github.com/hospitalrun" class="nav-link">Source</a>
-  <a href="/beta" class="nav-link">Beta</a>
-  <a href="/events" class="nav-link" target="_blank">Hack Events</a>
-  <a href="/team" class="nav-link" target="_blank">Team</a>
-  <a href="/blog" class="nav-link">Blog</a>
-  <a href="/contribute" class="nav-link" target="_blank">Contribute</a>
-  <a href="http://goo.gl/NCJDnJ" class="nav-link" target="_blank">Why HospitalRun?</a>
+  {% include nav-links.html %}
 </nav>
 
 <nav class="hamburger-site-nav">
@@ -20,13 +13,6 @@
   </a>
 
   <ul class="links">
-    <li><a href="/demo" class="nav-link">Demo</a></li>
-    <li><a href="https://github.com/hospitalrun" class="nav-link">Source</a></li>
-    <li><a href="/beta" class="nav-link">Beta</a></li>
-    <li><a href="/events" class="nav-link" target="_blank">Hack Events</a></li>
-    <li><a href="/team" class="nav-link" target="_blank">Team</a></li>
-    <li><a href="/blog" class="nav-link">Blog</a></li>
-    <li><a href="/contribute" class="nav-link" target="_blank">Contribute</a></li>
-    <li><a href="http://goo.gl/NCJDnJ" class="nav-link" target="_blank">Why HospitalRun?</a></li>
+    {% include nav-links.html %}
   </ul>
 </nav>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,3 +8,25 @@
   <a href="/contribute" class="nav-link" target="_blank">Contribute</a>
   <a href="http://goo.gl/NCJDnJ" class="nav-link" target="_blank">Why HospitalRun?</a>
 </nav>
+
+<nav class="hamburger-site-nav">
+  <a href="#" class="nav-trigger">
+    <svg class="menu-icon" xmlns="http://www.w3.org/2000/svg" width="28" height="21">
+      <path fill-rule="evenodd" clip-rule="evenodd" fill="#333333" d="M2.154,16.8h23.692C27.036,16.8,28,17.74,28,18.9
+        c0,1.16-0.964,2.1-2.154,2.1H2.154C0.964,21,0,20.06,0,18.9C0,17.74,0.964,16.8,2.154,16.8z M2.154,8.4h23.692
+        C27.036,8.4,28,9.34,28,10.5c0,1.16-0.964,2.1-2.154,2.1H2.154C0.964,12.6,0,11.66,0,10.5C0,9.34,0.964,8.4,2.154,8.4z M2.154,0
+        h23.692C27.036,0,28,0.94,28,2.1c0,1.16-0.964,2.1-2.154,2.1H2.154C0.964,4.2,0,3.26,0,2.1C0,0.94,0.964,0,2.154,0z"/>
+      </svg>
+  </a>
+
+  <ul class="links">
+    <li><a href="/demo" class="nav-link">Demo</a></li>
+    <li><a href="https://github.com/hospitalrun" class="nav-link">Source</a></li>
+    <li><a href="/beta" class="nav-link">Beta</a></li>
+    <li><a href="/events" class="nav-link" target="_blank">Hack Events</a></li>
+    <li><a href="/team" class="nav-link" target="_blank">Team</a></li>
+    <li><a href="/blog" class="nav-link">Blog</a></li>
+    <li><a href="/contribute" class="nav-link" target="_blank">Contribute</a></li>
+    <li><a href="http://goo.gl/NCJDnJ" class="nav-link" target="_blank">Why HospitalRun?</a></li>
+  </ul>
+</nav>

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -1,3 +1,10 @@
+@mixin center-flex-element($margin) {
+  width: $margin;
+  display: normal;
+  margin-left: auto;
+  margin-right: auto; 
+}
+
 .blog-sidebar {
   background-color: $navy-drk;
   border-radius: 4px;
@@ -8,6 +15,7 @@
     bottom: 48px;
     right: 40px;
   }
+  @media (max-width: 1030px) { display: none; }
 }
 
 .sidebar-header {
@@ -36,6 +44,22 @@
   width: 100%;
 }
 
+.post-wrapper,
+.index-list {
+  @media (max-width: 1030px) {
+    @include center-flex-element(85%)
+  }
+  @media (max-width: 780px) {
+    @include center-flex-element(95%)
+  }
+}
+
+.blog-posts,
+.post-wrapper {
+  display: flex;
+  flex-direction: row;
+}
+
 .index-list {
   display: flex;
   flex-direction: column;
@@ -52,12 +76,6 @@
   .post {
     margin-bottom: 30px;
   }
-}
-
-.blog-posts,
-.post-wrapper {
-  display: flex;
-  flex-direction: row;
 }
 
 .post {

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -6,8 +6,6 @@
 }
 
 .blog-sidebar {
-  background-color: $navy-drk;
-  border-radius: 4px;
   height: 100%;
   width: 300px;
   margin: {
@@ -15,21 +13,23 @@
     bottom: 48px;
     right: 40px;
   }
+  background-color: $navy-drk;
+  border-radius: 4px;
   @media (max-width: 1030px) { display: none; }
 }
 
 .sidebar-header {
-  font-size: 18px;
   padding-left: 20px;
   margin: 10px 0;
+  font-size: 18px;
 }
 
 .recent-posts {
-  background-color: lighten($navy-drk, 3%);
   padding: {
     top: 5px;
     bottom: 5px;
   }
+  background-color: lighten($navy-drk, 3%);
 
   h2 {
     padding-left: 20px;
@@ -85,22 +85,22 @@
   }
 
   h1 a {
-    color: white;
     font-size: 36px;
+    color: white;
     &:hover {
-      color: $green;
       text-decoration: none;
+      color: $green;
     }
   }
 
   p.meta { color: $gray-blue; }
 
   pre, code {
-    border: 1px solid $navy-gray;
-    background-color: $navy-drk;
     padding: 8px 12px;
     border-radius: 3px;
     font-size: 15px;
+    border: 1px solid $navy-gray;
+    background-color: $navy-drk;
   }
 
   code { padding: 1px 5px; }
@@ -118,26 +118,26 @@
 
   h1 {
     margin-bottom: 0px;
-    color: white;
     font-size: 36px;
     letter-spacing: -1px;
     line-height: 1;
+    color: white;
     font-weight: 300;
   }
 
   .meta {
+    margin-top: 5px;
     font-size: 15px;
     color: $medium-gray;
-    margin-top: 5px;
   }
 }
 
 .post-content {
 
   h1, h2, h3, h4, h5, h6 {
+    margin: 40px 0 20px;
     line-height: 1;
     font-weight: 300;
-    margin: 40px 0 20px;
   }
 
   h1 { font-size: 36px; }
@@ -155,12 +155,12 @@
   h4 { letter-spacing: -1px; }
 
   blockquote {
-    border-left: 4px solid $light-gray;
+    margin: 30px 0;
     padding-left: 20px;
     font-size: 18px;
-    opacity: .6;
     font-style: italic;
-    margin: 30px 0;
+    border-left: 4px solid $light-gray;
+    opacity: .6;
   }
 
   ul,

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -1,4 +1,5 @@
 .blog-sidebar {
+  @include media_max(1030px) { order: 2; @include center-element(100%); }
   height: 100%;
   width: 300px;
   margin: {
@@ -8,7 +9,6 @@
   }
   background-color: $navy-drk;
   @include border-radius(4px);
-  @include media_max(1030px) { display: none; }
 }
 
 .sidebar-header {
@@ -45,7 +45,10 @@
 }
 
 .blog-posts,
-.post-wrapper { @include add-flexbox(row); }
+.post-wrapper {
+  @include add-flexbox(row);
+  @include media_max(1030px) { @include add-flexbox(column); }
+}
 
 .index-list {
   @include add-flexbox(column);

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -41,6 +41,7 @@
 .index-list {
   @include media_max(1030px) { @include center-element(85%); }
   @include media_max(780px)  { @include center-element(95%); }
+  @include media_max(500px)  { @include center-element(100%); }
 }
 
 .blog-posts,

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -44,14 +44,10 @@
 }
 
 .blog-posts,
-.post-wrapper {
-  display: flex;
-  flex-direction: row;
-}
+.post-wrapper { @include add-flexbox(row); }
 
 .index-list {
-  display: flex;
-  flex-direction: column;
+  @include add-flexbox(column);
 
   h1 {
     margin-bottom: 0px;

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -1,10 +1,3 @@
-@mixin center-flex-element($margin) {
-  width: $margin;
-  display: normal;
-  margin-left: auto;
-  margin-right: auto; 
-}
-
 .blog-sidebar {
   height: 100%;
   width: 300px;
@@ -47,10 +40,10 @@
 .post-wrapper,
 .index-list {
   @media (max-width: 1030px) {
-    @include center-flex-element(85%)
+    @include center-element(85%)
   }
   @media (max-width: 780px) {
-    @include center-flex-element(95%)
+    @include center-element(95%)
   }
 }
 

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -7,7 +7,7 @@
     right: 40px;
   }
   background-color: $navy-drk;
-  border-radius: 4px;
+  @include border-radius(4px);
   @include media_max(1030px) { display: none; }
 }
 
@@ -83,7 +83,7 @@
 
   pre, code {
     padding: 8px 12px;
-    border-radius: 3px;
+    @include border-radius(3px);
     font-size: 15px;
     border: 1px solid $navy-gray;
     background-color: $navy-drk;

--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -8,7 +8,7 @@
   }
   background-color: $navy-drk;
   border-radius: 4px;
-  @media (max-width: 1030px) { display: none; }
+  @include media_max(1030px) { display: none; }
 }
 
 .sidebar-header {
@@ -39,12 +39,8 @@
 
 .post-wrapper,
 .index-list {
-  @media (max-width: 1030px) {
-    @include center-element(85%)
-  }
-  @media (max-width: 780px) {
-    @include center-element(95%)
-  }
+  @include media_max(1030px) { @include center-element(85%); }
+  @include media_max(780px)  { @include center-element(95%); }
 }
 
 .blog-posts,

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -27,6 +27,7 @@
 
   .site-nav {
     float: right;
+    @media (max-width: 1030px) { display: none; }
   }
 
   .nav-link {
@@ -34,6 +35,61 @@
     display: inline-block;
     padding: 0 10px;
     line-height: 63px;
+  }
+
+  .hamburger-site-nav {
+    position: fixed; z-index: 999;
+    top: 16px; right: 26px;
+    @include border-radius(4px);
+    background: $green;
+    border: 1px solid rgba(#333,.2);
+    @media (min-width: 1030px) { display: none; }
+
+    .nav-trigger {
+      @include border-radius(4px);
+      padding: 8px;
+      display: block;
+      text-align: right;
+      line-height: 1;
+
+      .menu-icon { display: block; }
+
+    }
+
+    .links {
+      list-style: none;
+      margin: 0;
+      padding: 0 15px 25px;
+      text-align: right;
+      display: none;
+      font-size: 22px;
+
+
+      > li:hover {
+        margin: 0 -16px;
+        padding: 0 15px;
+        background-color: $navy-drk;
+        color: white;
+        a  { color: white; }
+        }
+
+      a { 
+        text-decoration: none;
+        color: $navy-drk;
+      }
+    }
+
+    &:hover {
+       background: $green;
+
+      .links { display: block; }
+
+      .nav-trigger {
+
+        .menu-icon { display: inline-block; }
+
+      }
+    }
   }
 }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -46,7 +46,7 @@
     @include border-radius(4px);
     @include media_min(1031px) { display: none; }
     position: fixed; z-index: 999;
-    top: 16px; right: 26px;
+    top: 12px; right: 26px;
     background: $green;
     border: 1px solid rgba(#333,.2);
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -48,6 +48,8 @@
     background: $green;
     border: 1px solid rgba(#333,.2);
 
+    .nav-link { line-height: 50px; }
+
     .nav-trigger {
       @include border-radius(4px);
       padding: 8px;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -3,13 +3,6 @@
 
 // Site header
 
-@mixin center-element($width) {
-  width: $width;
-  display: normal;
-  margin-left: auto;
-  margin-right: auto; 
-}
-
 .site-header {
 
   .wrapper {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -17,7 +17,7 @@
       margin-right: 51px;
       @include media_max(1030px) { @include center-element(85%); }
       @include media_max(780px)  { @include center-element(95%); }
-      @include media_max(500px) { @include center-element(100%);  }
+      @include media_max(500px)  { @include center-element(100%); }
     }
   }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -67,17 +67,17 @@
       display: none;
       font-size: 20px;
 
-
-      > li:hover {
+      > a:hover {
         margin: 0 -16px;
-        padding: 0 15px;
+        padding: 0 26px;
         background-color: $navy-drk;
+        opacity: 1;
         color: white;
-        a  { color: white; }
         }
 
       a { 
         text-decoration: none;
+        display: block;
         color: $navy-drk;
       }
     }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -3,17 +3,30 @@
 
 // Site header
 
+@mixin center-element($width) {
+  width: $width;
+  display: normal;
+  margin-left: auto;
+  margin-right: auto; 
+}
+
 .site-header {
+
+  .wrapper {
+    display: flex;
+    flex-direction: row; 
+  }
 
   &.site {
     background: $navy-drk;
     @include clearfix;
 
     .logo {
-      display: block;
-      float: left;
       padding: 10px 0;
       margin-top: 6px;
+      margin-right: 51px;
+      @media (max-width: 1030px) { @include center-element(85%); }
+      @media (max-width: 780px) { @include center-element(95%); }
     }
   }
 
@@ -26,7 +39,6 @@
   }
 
   .site-nav {
-    float: right;
     @media (max-width: 1030px) { display: none; }
   }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -93,12 +93,14 @@
   }
 }
 
+
 // Site footer
 
 .site-footer {
   text-align: center;
   padding: 30px 0;
   color: #546A83;
+  @media (max-width: 1030px) { display: none; }
 
   .footer-link {
     color: $white;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -5,10 +5,7 @@
 
 .site-header {
 
-  .wrapper {
-    display: flex;
-    flex-direction: row; 
-  }
+  .wrapper { @include add-flexbox(row); }
 
   &.site {
     background: $navy-drk;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -48,7 +48,7 @@
     background: $green;
     border: 1px solid rgba(#333,.2);
 
-    .nav-link { line-height: 50px; }
+    .nav-link { line-height: 35px; }
 
     .nav-trigger {
       @include border-radius(4px);

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -56,7 +56,6 @@
       line-height: 1;
 
       .menu-icon { display: block; }
-
     }
 
     .links {
@@ -67,18 +66,17 @@
       display: none;
       font-size: 20px;
 
-      > a:hover {
-        margin: 0 -16px;
-        padding: 0 26px;
-        background-color: $navy-drk;
-        opacity: 1;
-        color: white;
-        }
-
       a { 
         text-decoration: none;
         display: block;
         color: $navy-drk;
+        &:hover {
+          margin: 0 -16px;
+          padding: 0 26px;
+          background-color: $navy-drk;
+          opacity: 1;
+          color: white;
+        }
       }
     }
 
@@ -90,7 +88,6 @@
       .nav-trigger {
 
         .menu-icon { display: inline-block; }
-
       }
     }
   }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -62,7 +62,7 @@
       list-style: none;
       margin: 0;
       padding: 0 15px 25px;
-      text-align: right;
+      text-align: left;
       display: none;
       font-size: 20px;
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -17,6 +17,7 @@
       margin-right: 51px;
       @include media_max(1030px) { @include center-element(85%); }
       @include media_max(780px)  { @include center-element(95%); }
+      @include media_max(500px) { @include center-element(100%);  }
     }
   }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -18,8 +18,8 @@
       padding: 10px 0;
       margin-top: 6px;
       margin-right: 51px;
-      @media (max-width: 1030px) { @include center-element(85%); }
-      @media (max-width: 780px) { @include center-element(95%); }
+      @include media_max(1030px) { @include center-element(85%); }
+      @include media_max(780px)  { @include center-element(95%); }
     }
   }
 
@@ -32,7 +32,7 @@
   }
 
   .site-nav {
-    @media (max-width: 1030px) { display: none; }
+    @include media_max(1030px) { display: none; }
   }
 
   .nav-link {
@@ -43,12 +43,12 @@
   }
 
   .hamburger-site-nav {
+    @include border-radius(4px);
+    @include media_min(1031px) { display: none; }
     position: fixed; z-index: 999;
     top: 16px; right: 26px;
-    @include border-radius(4px);
     background: $green;
     border: 1px solid rgba(#333,.2);
-    @media (min-width: 1030px) { display: none; }
 
     .nav-trigger {
       @include border-radius(4px);
@@ -105,7 +105,7 @@
   text-align: center;
   padding: 30px 0;
   color: #546A83;
-  @media (max-width: 1030px) { display: none; }
+  @include media_max(1030px) { display: none; }
 
   .footer-link {
     color: $white;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -117,7 +117,7 @@
   border: 1px solid #000;
   background-color: #333;
   color: #FFF;
-  border-radius: 3px;
+  @include border-radius(3px);
 }
 
 .post pre.terminal code { background-color: #333; }
@@ -141,7 +141,7 @@ body.demo {
     color: $green;
     padding: 2px 6px;
     background: rgba($green,.1);
-    border-radius: 3px;
+    @include border-radius(3px);
     text-transform: uppercase;
   }
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -64,7 +64,7 @@
       padding: 0 15px 25px;
       text-align: right;
       display: none;
-      font-size: 22px;
+      font-size: 20px;
 
 
       > li:hover {

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -13,6 +13,13 @@
   border-radius: $radius;
 }
 
+@mixin center-element($width) {
+  width: $width;
+  display: normal;
+  margin-left: auto;
+  margin-right: auto; 
+}
+
 // Clearfix
 //
 // Clears floats via mixin (avoid using as a class).

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -20,6 +20,11 @@
   margin-right: auto; 
 }
 
+@mixin add-flexbox($axis: row) {
+  display: flex;
+  flex-direction: $axis; 
+}
+
 // Clearfix
 //
 // Clears floats via mixin (avoid using as a class).


### PR DESCRIPTION
Add media queries for blog posts and navbar
Extract `nav-links` partial for collapsed and expanded navbar links
Extract Sass mixins: 
- `center-element`
- `add-flexbox`

Style adjustments
Bunch of small refactorings

# Browser screenshots

### Aligned logo with blog content below

<img width="1014" alt="screen shot 2016-11-05 at 5 39 44 pm" src="https://cloud.githubusercontent.com/assets/1353214/20033112/c03f973e-a399-11e6-9203-2c4d60003f90.png">

<img width="900" alt="screen shot 2016-11-05 at 7 48 48 pm" src="https://cloud.githubusercontent.com/assets/1353214/20033109/c02fc552-a399-11e6-91b3-59c5fb28a7a4.png">

###  Aligned expanded navbar with blog posts below

<img width="1332" alt="screen shot 2016-11-05 at 5 40 35 pm" src="https://cloud.githubusercontent.com/assets/1353214/20033110/c0340798-a399-11e6-9957-a28fc4c575e6.png">

<img width="1329" alt="screen shot 2016-11-05 at 5 40 21 pm" src="https://cloud.githubusercontent.com/assets/1353214/20033111/c03d2b3e-a399-11e6-8e23-e725a43ccbd1.png">

@jglovier Hope this PR goes smoother without weird style inconsistencies. 