### PR TITLE
Remove _blank and fix to 'Why HospitalRun'

### DIFF
--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -1,8 +1,8 @@
 <a href="/demo" class="nav-link">Demo</a>
 <a href="https://github.com/hospitalrun" class="nav-link">Source</a>
 <a href="/beta" class="nav-link">Beta</a>
-<a href="/events" class="nav-link" target="_blank">Hack Events</a>
-<a href="/team" class="nav-link" target="_blank">Team</a>
+<a href="/events" class="nav-link">Hack Events</a>
+<a href="/team" class="nav-link">Team</a>
 <a href="/blog" class="nav-link">Blog</a>
-<a href="/contribute" class="nav-link" target="_blank">Contribute</a>
-<a href="http://goo.gl/NCJDnJ" class="nav-link" target="_blank">Why HospitalRun?</a>
+<a href="/contribute" class="nav-link">Contribute</a>
+<a href="/blog/2016/06/why-hospitalrun" class="nav-link">Why HospitalRun?</a>


### PR DESCRIPTION
<img width="1254" alt="screen shot 2016-12-17 at 4 35 37 pm" src="https://cloud.githubusercontent.com/assets/4387026/21287559/ee18fe4a-c476-11e6-8a63-14810badef1d.png">

I changed 'Why HospitalRun' to the blog post instead of google doc, just like the footer!
Also removed the '_blank' form the links.

PR ref. #15 