### PR TITLE
Add styling to tryit page

### DIFF
--- a/_sass/_tryit.scss
+++ b/_sass/_tryit.scss
@@ -1,0 +1,48 @@
+// Try It styles
+// ---------------------------------------/
+
+.tryit-hero {
+  text-align: center;
+  
+  .hero-heading {
+    margin-top: 0.67em;
+  }
+}
+
+.tryit-content {
+  padding: 20px 0 30px;
+
+  .feature-heading {
+    font-size: 1.625rem;
+    color: $green;
+    margin: 0 0 25px;
+  }
+
+  .columns {
+    text-align: center;
+
+    .cta {
+      margin: 10px auto;
+    }
+
+    .screenshot-img {
+      width: auto;
+      height: 135px;
+    }
+  }
+}
+
+.columns {
+  @include clearfix();
+}
+
+.col-4 {
+  margin: 0 0 60px;
+  padding: 0 40px;
+
+  @include media_min($bp_mobile) {
+    float: left;
+    width: percentage(4 / 12);
+    margin: 0;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -13,6 +13,7 @@
 // Layouts
 @import "home";
 @import "event";
+@import "tryit";
 
 // Blog
 @import "blog";

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -1,54 +1,41 @@
 ---
 title: Try HospitalRun
+layout: default
 ---
-<html>
 
-  {% include head.html %}
+<div class="tryit-hero">
+  <h1 class="hero-heading">Try HospitalRun Now!</h1>
+  <p>Looking to use HospitalRun to support your clinic or hospital? Here are three ways to start.</p>
+</div>
 
-  <body class="page-home">
-
-    <div class="page-top">
-    {% include home/header.html %}
-    <div class="home-hero">
-      <div class="wrapper">
-
-        <h1 class="hero-heading">Try HospitalRun Now!</h1>
-        <p>Looking to use HospitalRun to support your clinic or hospital? Here are three ways to start.</p>
-
-        <!--column 1-->
-        <div>
-          <h2>Download It</h2>
-          <p>Through the magic of <a href="http://electron.atom.io" target="_blank">electron</a>, you can download and start using HospitalRun on your desktop. Later, you can <i>graduate</i> to a server-based implementation.</p>
-          <ul>
-            <li><a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta primary">Mac</a></li>
-            <li><a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a></li>
-          </ul>
-          <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0" />
-        </div>
-
-        <!--column 2-->
-        <div>
-          <h2>Install It</h2>
-          <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
-
-          <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta primary">Install Instructions</a>
-          <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md"><img src="/img/HospitalRun_deployment.jpeg" alt="HospitalRun Deployment Guide" class="screenshot-img" width="240" border="0" /></a>
-        </div>
-
-        <!--column 3-->
-        <div>
-          <h2>Demo It</h2>
-          <p>The <a href="/demo">demo site</a> is another great way to review what's available in HospitalRun.</p>
-
-          <a href="/demo" class="cta secondary">Go to the Demo</a>
-          <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0" />
-        </div>
-
+<div class="tryit-content">
+  <div class="columns">
+    <div class="col-4">
+      <h2 class="feature-heading">Download It</h2>
+      <div class="screenshot">
+        <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0">
       </div>
+      <p>Through the magic of <a href="http://electron.atom.io" target="_blank">electron</a>, you can download and start using HospitalRun on your desktop. Later, you can <em>graduate</em> to a server-based implementation.</p>
+      <a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta primary">Mac</a>
+      <a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a>
     </div>
+
+    <div class="col-4">
+      <h2 class="feature-heading">Install It</h2>
+      <div class="screenshot">
+        <img src="/img/HospitalRun_deployment.jpeg" alt="HospitalRun Deployment Guide" class="screenshot-img" width="240" border="0"></a>
+      </div>
+      <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
+      <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta primary">Install Instructions</a>
     </div>
-    {% include footer.html %}
 
-
-    </body>
-</html>
+    <div class="col-4">
+      <h2 class="feature-heading">Demo It</h2>
+      <div class="screenshot">
+        <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0">
+      </div>
+      <p>The <a href="/demo">demo site</a> is another great way to review what's available in HospitalRun.</p>
+      <a href="/demo" class="cta secondary">Go to the Demo</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Fix for #50 

@tangollama see screenshot below for what the tryit page looks like with these changes.

![tryit](https://cloud.githubusercontent.com/assets/6332791/25553690/e5518092-2c6e-11e7-946c-c0c4ea545d47.png)
