### PR TITLE
Change the homepage to introduce "try it"

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,12 +2,12 @@
   <div class="wrapper">
 
     <nav class="footer-nav">
-      <a href="/blog/2016/06/why-hospitalrun" class="footer-link">Why HospitalRun?</a>&bull;
+      <a href="/blog/2016/06/why-hospitalrun" class="footer-link">Why HospitalRun</a>&bull;
       <a href="https://github.com/hospitalrun" class="footer-link">Source</a> &bull;
       <a href="/events" class="footer-link" target="_blank">Hack Events</a> &bull;
       <a href="/blog" class="footer-link">Blog</a> &bull;
       <a href="/contribute" class="footer-link">Contribute</a> &bull;
-      <a href="/tryit" class="footer-link">Try it!</a>
+      <a href="/tryit" class="footer-link">Try it</a>
     </nav>
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,12 +2,12 @@
   <div class="wrapper">
 
     <nav class="footer-nav">
-      <a href="/demo" class="footer-link">Demo</a> &bull;
+      <a href="/blog/2016/06/why-hospitalrun" class="footer-link">Why HospitalRun?</a>&bull;
       <a href="https://github.com/hospitalrun" class="footer-link">Source</a> &bull;
       <a href="/events" class="footer-link" target="_blank">Hack Events</a> &bull;
       <a href="/blog" class="footer-link">Blog</a> &bull;
       <a href="/contribute" class="footer-link">Contribute</a> &bull;
-      <a href="/blog/2016/06/why-hospitalrun" class="footer-link">Why HospitalRun?</a>
+      <a href="/tryit" class="footer-link">Try it!</a>
     </nav>
   </div>
 </footer>

--- a/_includes/home/hero.html
+++ b/_includes/home/hero.html
@@ -4,7 +4,7 @@
     <h1 class="hero-heading">Open source software for<br> developing world hospitals.</h1>
 
     <div class="cta-row">
-      <a href="/tryit" class="cta primary">Try it Now!</a>
+      <a href="/tryit" class="cta primary">Try HospitalRun</a>
       <a href="https://github.com/HospitalRun/hospitalrun-frontend" class="cta secondary">View source on GitHub</a>
     </div>
 

--- a/_includes/home/hero.html
+++ b/_includes/home/hero.html
@@ -4,7 +4,7 @@
     <h1 class="hero-heading">Open source software for<br> developing world hospitals.</h1>
 
     <div class="cta-row">
-      <a href="/demo" class="cta primary">View demo</a>
+      <a href="/tryit" class="cta primary">Try it Now!</a>
       <a href="https://github.com/HospitalRun/hospitalrun-frontend" class="cta secondary">View source on GitHub</a>
     </div>
 

--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -1,6 +1,6 @@
-<a href="/demo" class="nav-link">Demo</a>
 <a href="https://github.com/hospitalrun" class="nav-link">Source</a>
+<a href="/blog/2016/06/why-hospitalrun" class="nav-link">Why HospitalRun?</a>
 <a href="/events" class="nav-link">Hack Events</a>
 <a href="/blog" class="nav-link">Blog</a>
 <a href="/contribute" class="nav-link">Contribute</a>
-<a href="/blog/2016/06/why-hospitalrun" class="nav-link">Why HospitalRun?</a>
+<a href="/tryit" class="nav-link cta">Try it!</a>

--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -1,5 +1,5 @@
-<a href="https://github.com/hospitalrun" class="nav-link">Source</a>
 <a href="/blog/2016/06/why-hospitalrun" class="nav-link">Why HospitalRun?</a>
+<a href="https://github.com/hospitalrun" class="nav-link">Source</a>
 <a href="/events" class="nav-link">Hack Events</a>
 <a href="/blog" class="nav-link">Blog</a>
 <a href="/contribute" class="nav-link">Contribute</a>

--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -1,6 +1,6 @@
-<a href="/blog/2016/06/why-hospitalrun" class="nav-link">Why HospitalRun?</a>
+<a href="/blog/2016/06/why-hospitalrun" class="nav-link">Why HospitalRun</a>
 <a href="https://github.com/hospitalrun" class="nav-link">Source</a>
 <a href="/events" class="nav-link">Hack Events</a>
 <a href="/blog" class="nav-link">Blog</a>
 <a href="/contribute" class="nav-link">Contribute</a>
-<a href="/tryit" class="nav-link cta">Try it!</a>
+<a href="/tryit" class="nav-link cta">Try it</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,5 +15,14 @@
 
     {% include footer.html %}
 
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-98265531-1', 'auto');
+      ga('send', 'pageview');
+    </script>
     </body>
 </html>

--- a/_sass/_tryit.scss
+++ b/_sass/_tryit.scss
@@ -1,0 +1,48 @@
+// Try It styles
+// ---------------------------------------/
+
+.tryit-hero {
+  text-align: center;
+  
+  .hero-heading {
+    margin-top: 0.67em;
+  }
+}
+
+.tryit-content {
+  padding: 20px 0 30px;
+
+  .feature-heading {
+    font-size: 1.625rem;
+    color: $green;
+    margin: 0 0 25px;
+  }
+
+  .columns {
+    text-align: center;
+
+    .cta {
+      margin: 10px auto;
+    }
+
+    .screenshot-img {
+      width: auto;
+      height: 135px;
+    }
+  }
+}
+
+.columns {
+  @include clearfix();
+}
+
+.col-4 {
+  margin: 0 0 60px;
+  padding: 0 40px;
+
+  @include media_min($bp_mobile) {
+    float: left;
+    width: percentage(4 / 12);
+    margin: 0;
+  }
+}

--- a/_sass/_tryit.scss
+++ b/_sass/_tryit.scss
@@ -3,9 +3,14 @@
 
 .tryit-hero {
   text-align: center;
-  
+
   .hero-heading {
     margin-top: 0.67em;
+    line-height: 2.5rem;
+  }
+
+  p {
+    font-size: 1.25rem;
   }
 }
 
@@ -28,6 +33,7 @@
     .screenshot-img {
       width: auto;
       height: 135px;
+      border-radius: 3px;
     }
   }
 }

--- a/_sass/_tryit.scss
+++ b/_sass/_tryit.scss
@@ -30,6 +30,16 @@
       margin: 10px auto;
     }
 
+    h3 {
+      line-height: 1rem;
+      font-size: 1.25rem;
+      margin-bottom: 0px;
+    }
+
+    p {
+      margin: .5rem .5rem 2rem .5rem;
+    }
+
     .screenshot-img {
       width: auto;
       height: 135px;

--- a/css/main.scss
+++ b/css/main.scss
@@ -13,6 +13,7 @@
 // Layouts
 @import "home";
 @import "event";
+@import "tryit";
 
 // Blog
 @import "blog";

--- a/demo/index.md
+++ b/demo/index.md
@@ -5,54 +5,54 @@ layout: default
 
 <div class="tryit-hero">
   <h1 class="hero-heading">Accessing the HospitalRun Demo Site</h1>
-  <p>Go to <a href="https://beta.hospitalrun.io" target="_blank">https://beta.hospitalrun.io</a> and use any of the following login credentials to demo the software as a user in each of the these default roles (you can change permissions in your own instance).</p>
+  <p>Go to <a href="https://beta.hospitalrun.io" target="_blank">https://beta.hospitalrun.io</a> and use any of the following credentials.</p>
 </div>
 
 <div class="tryit-content">
   <div class="columns">
     <div class="col-4">
-      <h3 class="feature-heading">Clinical</h3>
+      <h2 class="feature-heading">Clinical</h2>
 
-      <h4>Doctor</h4>
+      <h3>Doctor</h3>
       <p>hr.doctor@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Nurse</h4>
+      <h3>Nurse</h3>
       <p>hr.nurse@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Nurse Manager</h4>
+      <h3>Nurse Manager</h3>
       <p>hr.nurse.manager@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Social Worker</h4>
+      <h3>Social Worker</h3>
       <p>hr.social.worker@hospitalrun.io<br/>PW: HRt3st12</p>
 
     </div>
 
     <div class="col-4">
-      <h3 class="feature-heading">Administrative</h3>
+      <h2 class="feature-heading">Administrative</h2>
 
-      <h4>Hospital Administrator</h4>
+      <h3>Hospital Administrator</h3>
       <p>hr.hospital.admin@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Business Office</h4>
+      <h3>Business Office</h3>
       <p>hr.hospital.office@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Inventory Manager</h4>
+      <h3>Inventory Manager</h3>
       <p>hr.inventory.manager@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Patient Administrator</h4>
+      <h3>Patient Administrator</h3>
       <p>hr.patient.admin@hospitalrun.io<br/>PW: HRt3st12</p>
     </div>
 
     <div class="col-4">
-      <h3 class="feature-heading">Support</h3>
+      <h2 class="feature-heading">Support</h2>
 
-      <h4>Imaging Technician</h4>
+      <h3>Imaging Technician</h3>
       <p>hr.imaging.tech@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Lab Technician</h4>
+      <h3>Lab Technician</h3>
       <p>hr.lab.tech@hospitalrun.io<br/>PW: HRt3st12</p>
 
-      <h4>Pharmacist</h4>
+      <h3>Pharmacist</h3>
       <p>hr.pharmacist@hospitalrun.io<br/>PW: HRt3st12</p>
     </div>
   </div>

--- a/demo/index.md
+++ b/demo/index.md
@@ -1,55 +1,59 @@
 ---
-title: Accessing the HospitalRun demo site
-layout: demo
+title: Accessing the HospitalRun Demo Site
+layout: default
 ---
 
-# Accessing the HospitalRun demo site
+<div class="tryit-hero">
+  <h1 class="hero-heading">Accessing the HospitalRun Demo Site</h1>
+  <p>Go to <a href="https://beta.hospitalrun.io" target="_blank">https://beta.hospitalrun.io</a> and use any of the following login credentials to demo the software as a user in each of the these default roles (you can change permissions in your own instance).</p>
+</div>
 
-## Visit: [beta.hospitalrun.io](https://beta.hospitalrun.io/){:target="_blank"}
+<div class="tryit-content">
+  <div class="columns">
+    <div class="col-4">
+      <h3 class="feature-heading">Clinical</h3>
 
-## Account info
-Use any of the following login credentials to demo the software as a user with these permissions.
+      <h4>Doctor</h4>
+      <p>ID: hr.doctor@hospitalrun.io<br/>PW: HRt3st12</p>
 
-### Hospital Admin role
-**id:** hr.hospital.admin@hospitalrun.io
-**pw:** HRt3st12
+      <h4>Nurse</h4>
+      <p>ID: hr.nurse@hospitalrun.io<br/>PW: HRt3st12</p>
 
-### Business Office role
-**id:** hr.business.office@hospitalrun.io
-**pw:** HRt3st12
+      <h4>Nurse Manager</h4>
+      <p>ID: hr.nurse.manager@hospitalrun.io<br/>PW: HRt3st12</p>
 
-### Doctor role
-**id:** hr.doctor@hospitalrun.io
-**pw:** HRt3st12
+      <h4>Social Worker</h4>
+      <p>ID: hr.social.worker@hospitalrun.io<br/>PW: HRt3st12</p>
 
-### Imaging Technician role
-**id:** hr.imaging.tech@hospitalrun.io
-**pw:** HRt3st12
+    </div>
 
-### Inventory Manager role
-**id:** hr.inventory.manager@hospitalrun.io
-**pw:** HRt3st12
+    <div class="col-4">
+      <h3 class="feature-heading">Administrative</h3>
 
-### Lab Technician role
-**id:** hr.lab.tech@hospitalrun.io
-**pw:** HRt3st12
+      <h4>Hospital Administrator</h4>
+      <p>ID: hr.hospital.admin@hospitalrun.io<br/>PW: HRt3st12</p>
 
-### Nurse Manager role
-**id:** hr.nurse.manager@hospitalrun.io
-**pw:** HRt3st12
+      <h4>Business Office</h4>
+      <p>ID: hr.hospital.office@hospitalrun.io<br/>PW: HRt3st12</p>
 
-### Nurse role
-**id:** hr.nurse@cureinternational.org
-**pw:** HRt3st12
+      <h4>Inventory Manager</h4>
+      <p>ID: hr.inventory.manager@hospitalrun.io<br/>PW: HRt3st12</p>
 
-### Patient Administrator role
-**id:** hr.patient.admin@hospitalrun.io
-**pw:** HRt3st12
+      <h4>Patient Administrator</h4>
+      <p>ID: hr.patient.admin@hospitalrun.io<br/>PW: HRt3st12</p>
+    </div>
 
-### Pharmacist role
-**id:** hr.pharmacist@hospitalrun.io
-**pw:** HRt3st12
+    <div class="col-4">
+      <h3 class="feature-heading">Support</h3>
 
-### Social Worker role
-**id:** hr.social.worker@hospitalrun.io
-**pw:** HRt3st12
+      <h4>Imaging Technician</h4>
+      <p>ID: hr.imaging.tech@hospitalrun.io<br/>PW: HRt3st12</p>
+
+      <h4>Lab Technician</h4>
+      <p>ID: hr.lab.tech@hospitalrun.io<br/>PW: HRt3st12</p>
+
+      <h4>Pharmacist</h4>
+      <p>ID: hr.pharmacist@hospitalrun.io<br/>PW: HRt3st12</p>
+    </div>
+  </div>
+</div>

--- a/demo/index.md
+++ b/demo/index.md
@@ -14,16 +14,16 @@ layout: default
       <h3 class="feature-heading">Clinical</h3>
 
       <h4>Doctor</h4>
-      <p>ID: hr.doctor@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.doctor@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Nurse</h4>
-      <p>ID: hr.nurse@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.nurse@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Nurse Manager</h4>
-      <p>ID: hr.nurse.manager@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.nurse.manager@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Social Worker</h4>
-      <p>ID: hr.social.worker@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.social.worker@hospitalrun.io<br/>PW: HRt3st12</p>
 
     </div>
 
@@ -31,29 +31,29 @@ layout: default
       <h3 class="feature-heading">Administrative</h3>
 
       <h4>Hospital Administrator</h4>
-      <p>ID: hr.hospital.admin@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.hospital.admin@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Business Office</h4>
-      <p>ID: hr.hospital.office@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.hospital.office@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Inventory Manager</h4>
-      <p>ID: hr.inventory.manager@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.inventory.manager@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Patient Administrator</h4>
-      <p>ID: hr.patient.admin@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.patient.admin@hospitalrun.io<br/>PW: HRt3st12</p>
     </div>
 
     <div class="col-4">
       <h3 class="feature-heading">Support</h3>
 
       <h4>Imaging Technician</h4>
-      <p>ID: hr.imaging.tech@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.imaging.tech@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Lab Technician</h4>
-      <p>ID: hr.lab.tech@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.lab.tech@hospitalrun.io<br/>PW: HRt3st12</p>
 
       <h4>Pharmacist</h4>
-      <p>ID: hr.pharmacist@hospitalrun.io<br/>PW: HRt3st12</p>
+      <p>hr.pharmacist@hospitalrun.io<br/>PW: HRt3st12</p>
     </div>
   </div>
 </div>

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -15,7 +15,7 @@ layout: default
       <div class="screenshot">
         <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0">
       </div>
-      <p>Download and start using HospitalRun on your desktop. Later, <em>graduate</em> to a server implementation.</p>
+      <p>Start using HospitalRun on your desktop. Later, <em>graduate</em> to a server implementation.</p>
       <a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta secondary">Mac</a>
       <a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a>
     </div>

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -17,7 +17,7 @@ layout: default
       </div>
       <p>Start using HospitalRun on your desktop. Later, <em>graduate</em> to a server implementation.</p>
       <a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta secondary">Mac</a>
-      <a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a>
+      <!--<a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a>-->
     </div>
 
     <div class="col-4">

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -1,0 +1,54 @@
+---
+title: Try HospitalRun
+---
+<html>
+
+  {% include head.html %}
+
+  <body class="page-home">
+
+    <div class="page-top">
+    {% include home/header.html %}
+    <div class="home-hero">
+      <div class="wrapper">
+
+        <h1 class="hero-heading">Try HospitalRun Now!</h1>
+        <p>Looking to use HospitalRun to support your clinic or hospital? Here are three ways to start.</p>
+
+        <!--column 1-->
+        <div>
+          <h2>Download It</h2>
+          <p>Through the magic of <a href="http://electron.atom.io" target="_blank">electron</a>, you can download and start using HospitalRun on your desktop. Later, you can <i>graduate</i> to a server-based implementation.</p>
+          <ul>
+            <li><a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta primary">Mac</a></li>
+            <li><a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a></li>
+          </ul>
+          <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0" />
+        </div>
+
+        <!--column 2-->
+        <div>
+          <h2>Install It</h2>
+          <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
+
+          <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta primary">Install Instructions</a>
+          <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md"><img src="/img/HospitalRun_deployment.jpeg" alt="HospitalRun Deployment Guide" class="screenshot-img" width="240" border="0" /></a>
+        </div>
+
+        <!--column 3-->
+        <div>
+          <h2>Demo It</h2>
+          <p>The <a href="/demo">demo site</a> is another great way to review what's available in HospitalRun.</p>
+
+          <a href="/demo" class="cta secondary">Go to the Demo</a>
+          <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0" />
+        </div>
+
+      </div>
+    </div>
+    </div>
+    {% include footer.html %}
+
+
+    </body>
+</html>

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -28,7 +28,7 @@ layout: default
       </div>
       <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" target="_blank">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
       <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta secondary" target="_blank">Install Instructions</a>
-      <p>Help <a href="https://github.com/HospitalRun/hospitalrun-server" target="_blank">improve and enhance</a> the install instructions.</p>
+      <p>Help <a href="https://github.com/HospitalRun/hospitalrun-server" target="_blank">improve and enhance</a> the deployment process.</p>
     </div>
 
     <div class="col-4">

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -1,54 +1,41 @@
 ---
 title: Try HospitalRun
+layout: default
 ---
-<html>
 
-  {% include head.html %}
+<div class="tryit-hero">
+  <h1 class="hero-heading">Try HospitalRun Now!</h1>
+  <p>Looking to use HospitalRun to support your clinic or hospital? Here are three ways to start.</p>
+</div>
 
-  <body class="page-home">
-
-    <div class="page-top">
-    {% include home/header.html %}
-    <div class="home-hero">
-      <div class="wrapper">
-
-        <h1 class="hero-heading">Try HospitalRun Now!</h1>
-        <p>Looking to use HospitalRun to support your clinic or hospital? Here are three ways to start.</p>
-
-        <!--column 1-->
-        <div>
-          <h2>Download It</h2>
-          <p>Through the magic of <a href="http://electron.atom.io" target="_blank">electron</a>, you can download and start using HospitalRun on your desktop. Later, you can <i>graduate</i> to a server-based implementation.</p>
-          <ul>
-            <li><a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta primary">Mac</a></li>
-            <li><a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a></li>
-          </ul>
-          <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0" />
-        </div>
-
-        <!--column 2-->
-        <div>
-          <h2>Install It</h2>
-          <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
-
-          <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta primary">Install Instructions</a>
-          <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md"><img src="/img/HospitalRun_deployment.jpeg" alt="HospitalRun Deployment Guide" class="screenshot-img" width="240" border="0" /></a>
-        </div>
-
-        <!--column 3-->
-        <div>
-          <h2>Demo It</h2>
-          <p>The <a href="/demo">demo site</a> is another great way to review what's available in HospitalRun.</p>
-
-          <a href="/demo" class="cta secondary">Go to the Demo</a>
-          <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0" />
-        </div>
-
+<div class="tryit-content">
+  <div class="columns">
+    <div class="col-4">
+      <h2 class="feature-heading">Download It</h2>
+      <div class="screenshot">
+        <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0">
       </div>
+      <p>Through the magic of <a href="http://electron.atom.io" target="_blank">electron</a>, you can download and start using HospitalRun on your desktop. Later, you can <em>graduate</em> to a server-based implementation.</p>
+      <a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta primary">Mac</a>
+      <a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a>
     </div>
+
+    <div class="col-4">
+      <h2 class="feature-heading">Install It</h2>
+      <div class="screenshot">
+        <img src="/img/HospitalRun_deployment.jpeg" alt="HospitalRun Deployment Guide" class="screenshot-img" width="240" border="0"></a>
+      </div>
+      <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
+      <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta primary">Install Instructions</a>
     </div>
-    {% include footer.html %}
 
-
-    </body>
-</html>
+    <div class="col-4">
+      <h2 class="feature-heading">Demo It</h2>
+      <div class="screenshot">
+        <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0">
+      </div>
+      <p>The <a href="/demo">demo site</a> is another great way to review what's available in HospitalRun.</p>
+      <a href="/demo" class="cta secondary">Go to the Demo</a>
+    </div>
+  </div>
+</div>

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -17,6 +17,7 @@ layout: default
       </div>
       <p>Start using HospitalRun on your desktop. Later, <em>graduate</em> to a server implementation.</p>
       <a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta secondary">Mac</a>
+      <p>Want a Windows install? <br/>Contribute <a href="https://github.com/HospitalRun/hospitalrun-frontend/issues/1074" target="_blank">here</a> or <a href="https://github.com/HospitalRun/hospitalrun-frontend/issues/1075" target="_blank">here</a>.</p>
       <!--<a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a>-->
     </div>
 
@@ -25,8 +26,9 @@ layout: default
       <div class="screenshot">
         <img src="/img/HospitalRun_deployment.jpeg" alt="HospitalRun Deployment Guide" class="screenshot-img" width="240" border="0"></a>
       </div>
-      <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
-      <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta secondary">Install Instructions</a>
+      <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" target="_blank">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
+      <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta secondary" target="_blank">Install Instructions</a>
+      <p>Help <a href="https://github.com/HospitalRun/hospitalrun-server" target="_blank">improve and enhance</a> the install instructions.</p>
     </div>
 
     <div class="col-4">
@@ -36,6 +38,7 @@ layout: default
       </div>
       <p>The <a href="/demo">demo site</a> is another great way to review what's available in HospitalRun.</p>
       <a href="/demo" class="cta secondary">Go to the Demo</a>
+      <p>Join our <a href="https://hospitalrun-slackin.herokuapp.com" target="_blank">Slack</a> and help improve the #demo experience.</p>
     </div>
   </div>
 </div>

--- a/tryit/index.md
+++ b/tryit/index.md
@@ -4,7 +4,7 @@ layout: default
 ---
 
 <div class="tryit-hero">
-  <h1 class="hero-heading">Try HospitalRun Now!</h1>
+  <h1 class="hero-heading">Great Options to Try HospitalRun</h1>
   <p>Looking to use HospitalRun to support your clinic or hospital? Here are three ways to start.</p>
 </div>
 
@@ -15,8 +15,8 @@ layout: default
       <div class="screenshot">
         <img src="/img/screenshot-mock-sm.jpg" alt="HospitalRun user interface screenshot" class="screenshot-img" width="240" border="0">
       </div>
-      <p>Through the magic of <a href="http://electron.atom.io" target="_blank">electron</a>, you can download and start using HospitalRun on your desktop. Later, you can <em>graduate</em> to a server-based implementation.</p>
-      <a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta primary">Mac</a>
+      <p>Download and start using HospitalRun on your desktop. Later, <em>graduate</em> to a server implementation.</p>
+      <a href="https://releases.hospitalrun.io/updates/macos/HospitalRun.dmg" class="cta secondary">Mac</a>
       <a href="https://releases.hospitalrun.io/updates/win32/HospitalRun.exe" class="cta secondary">Windows</a>
     </div>
 
@@ -26,7 +26,7 @@ layout: default
         <img src="/img/HospitalRun_deployment.jpeg" alt="HospitalRun Deployment Guide" class="screenshot-img" width="240" border="0"></a>
       </div>
       <p>Follow the <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md">installation instructions</a> to deploy HospitalRun to a private server or cloud service.</p>
-      <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta primary">Install Instructions</a>
+      <a href="https://github.com/HospitalRun/hospitalrun-server/blob/master/DEPLOYMENT_GUIDE.md" class="cta secondary">Install Instructions</a>
     </div>
 
     <div class="col-4">


### PR DESCRIPTION
This PR changes the homepage to introduce a "try it" section that offers three new options: download, install, or view the demo. I'm ready to go with this as soon as both of you are.

I also added Google Analytics to the page so that we can track traffic in the weeks ahead.
<img width="834" alt="screen shot 2017-04-29 at 8 20 02 am" src="https://cloud.githubusercontent.com/assets/929261/25555444/d284e800-2cb4-11e7-9374-fd1f0daa9707.png">
<img width="1280" alt="screen shot 2017-04-29 at 8 20 16 am" src="https://cloud.githubusercontent.com/assets/929261/25555446/d2964a8c-2cb4-11e7-9325-f24ed3fb1453.png">
<img width="1280" alt="screen shot 2017-04-29 at 8 20 37 am" src="https://cloud.githubusercontent.com/assets/929261/25555445/d29560d6-2cb4-11e7-9318-005567431b70.png">




